### PR TITLE
fix frameworkLint + clean coding

### DIFF
--- a/.framework-config
+++ b/.framework-config
@@ -11,7 +11,7 @@ FRAMEWORK_FUNCTIONS_IGNORE_REGEXP="${FRAMEWORK_FUNCTIONS_IGNORE_REGEXP:-^(Namesp
 # describe the files that do not contain function to be imported
 NON_FRAMEWORK_FILES_REGEXP="${NON_FRAMEWORK_FILES_REGEXP:-(^bin/|^hooks/|^test.sh$|^preCommitTest.sh$|^.github/|^.docker/createUser.|.framework-config|.bats$|/testsData/|^manualTests/|/_.sh$|/ZZZ.sh$|/__all.sh$|^src/_binaries|^src/_includes|^src/batsHeaders.sh$|^src/_standalone)}"
 # describe the files that are allowed to not have an associated bats file
-BATS_FILE_NOT_NEEDED_REGEXP="${BATS_FILE_NOT_NEEDED_REGEXP:-(^bin/|.framework-config|^.docker/|^.github/|.bats$|/testsData/|^manualTests/|/_.sh$|/ZZZ.sh$|/__all.sh$|^src/batsHeaders.sh$|^src/_includes)}"
+BATS_FILE_NOT_NEEDED_REGEXP="${BATS_FILE_NOT_NEEDED_REGEXP:-(^bin/|.framework-config|^.docker/|^.github/|.bats$|/testsData/|^manualTests/|/_.sh$|/ZZZ.sh$|/__all.sh$|^src/batsHeaders.sh$|^src/_includes|-(main|options)\.sh$)}"
 # describe the files that are allowed to not have a function matching the filename
 FRAMEWORK_FILES_FUNCTION_MATCHING_IGNORE_REGEXP="${FRAMEWORK_FILES_FUNCTION_MATCHING_IGNORE_REGEXP:-^bin/|^.github/|^\.framework-config$|/testsData/|^manualTests/|\.bats$|src/Options/_bats.sh}"
 # Source directories

--- a/.pre-commit-config-github.yaml
+++ b/.pre-commit-config-github.yaml
@@ -160,7 +160,7 @@ repos:
         args:
           [
             --expected-warnings-count,
-            "73",
+            "62",
             --format,
             plain,
             --theme,
@@ -172,7 +172,7 @@ repos:
         args:
           [
             --expected-warnings-count,
-            "73",
+            "62",
             --format,
             checkstyle,
             --theme,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
         args:
           [
             --expected-warnings-count,
-            "73",
+            "62",
             --format,
             plain,
             --theme,
@@ -167,7 +167,7 @@ repos:
         args:
           [
             --expected-warnings-count,
-            "73",
+            "62",
             --format,
             checkstyle,
             --theme,

--- a/bin/awkLint
+++ b/bin/awkLint
@@ -385,7 +385,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -623,6 +623,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -999,31 +1028,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1057,7 +1061,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1072,7 +1076,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1566,12 +1570,14 @@ awkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1589,6 +1595,7 @@ awkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1605,6 +1612,7 @@ awkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/buildPushDockerImage
+++ b/bin/buildPushDockerImage
@@ -336,7 +336,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -589,19 +589,6 @@ Log::displayInfo() {
 }
 
 
-# @description Display message using warning color (yellow)
-# @arg $1 message:String the message to display
-# @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
-# @env LOG_CONTEXT String allows to contextualize the log
-Log::displayWarning() {
-  if ((BASH_FRAMEWORK_DISPLAY_LEVEL >= __LEVEL_WARNING)); then
-    Log::computeDuration
-    echo -e "${__WARNING_COLOR}WARN    - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
-  fi
-  Log::logWarning "$1"
-}
-
-
 # @description Display message using error color (red) and exit immediately with error status 1
 # @arg $1 message:String the message to display
 # @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
@@ -611,6 +598,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -681,15 +697,6 @@ Log::logMessage() {
     date="$(date '+%Y-%m-%d %H:%M:%S')"
     touch "${BASH_FRAMEWORK_LOG_FILE}"
     printf "%s|%7s|%s\n" "${date}" "${levelMsg}" "${msg}" >>"${BASH_FRAMEWORK_LOG_FILE}"
-  fi
-}
-
-
-# @description log message to file
-# @arg $1 message:String the message to display
-Log::logWarning() {
-  if ((BASH_FRAMEWORK_LOG_LEVEL >= __LEVEL_WARNING)); then
-    Log::logMessage "${2:-WARNING}" "$1"
   fi
 }
 
@@ -987,31 +994,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1045,7 +1027,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1060,7 +1042,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1677,12 +1659,14 @@ buildPushDockerImageCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1700,6 +1684,7 @@ buildPushDockerImageCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1716,6 +1701,7 @@ buildPushDockerImageCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 
@@ -1744,6 +1730,7 @@ buildPushDockerImageCommandHelp() {
   echo
   Array::wrap2 ' ' 76 8 "      - ${__OPTION_COLOR}ubuntu:${__RESET_COLOR} ubuntu based docker image"
   echo
+
   Array::wrap2 ' ' 76 6 "    Default value: " "ubuntu"
   echo
 
@@ -1756,12 +1743,14 @@ buildPushDockerImageCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}5.0${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}5.1${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}5.2${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "5.2"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--bash-base-image <bash-base-image>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "bash bash image to use (eg: ubuntu:20.04, amd64/bash:4.4-alpine3.18)"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "ubuntu:20.04"
   echo

--- a/bin/definitionLint
+++ b/bin/definitionLint
@@ -332,7 +332,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -540,19 +540,6 @@ Log::displaySuccess() {
 }
 
 
-# @description Display message using warning color (yellow)
-# @arg $1 message:String the message to display
-# @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
-# @env LOG_CONTEXT String allows to contextualize the log
-Log::displayWarning() {
-  if ((BASH_FRAMEWORK_DISPLAY_LEVEL >= __LEVEL_WARNING)); then
-    Log::computeDuration
-    echo -e "${__WARNING_COLOR}WARN    - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
-  fi
-  Log::logWarning "$1"
-}
-
-
 # @description Display message using error color (red) and exit immediately with error status 1
 # @arg $1 message:String the message to display
 # @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
@@ -562,6 +549,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -641,15 +657,6 @@ Log::logMessage() {
 Log::logSuccess() {
   if ((BASH_FRAMEWORK_LOG_LEVEL >= __LEVEL_INFO)); then
     Log::logMessage "${2:-SUCCESS}" "$1"
-  fi
-}
-
-
-# @description log message to file
-# @arg $1 message:String the message to display
-Log::logWarning() {
-  if ((BASH_FRAMEWORK_LOG_LEVEL >= __LEVEL_WARNING)); then
-    Log::logMessage "${2:-WARNING}" "$1"
   fi
 }
 
@@ -1128,31 +1135,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1186,7 +1168,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1201,7 +1183,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1776,6 +1758,7 @@ definitionLintCommandHelp() {
   echo "    Possible values: "
   echo -e "      - ${__OPTION_COLOR}plain${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}checkstyle${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "plain"
   echo
   echo
@@ -1823,12 +1806,14 @@ definitionLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1846,6 +1831,7 @@ definitionLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1862,6 +1848,7 @@ definitionLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/doc
+++ b/bin/doc
@@ -405,7 +405,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -710,11 +710,21 @@ Github::defaultInstall() {
   if [[ "$(type -t "${installCallback}")" = "function" ]]; then
     ${installCallback} "${newSoftware}" "${targetFile}" "${version}"
   else
-    ${SUDO:-} mv "${newSoftware}" "${targetFile}"
-    ${SUDO:-} chmod +x "${targetFile}"
+    ${SUDO:-} mv "${newSoftware}" "${targetFile}" || {
+      Log::displayError "Failed to move ${newSoftware} to ${targetFile}"
+      return 1
+    }
+    ${SUDO:-} chmod +x "${targetFile}" || {
+      Log::displayError "Failed to set execution bit on ${targetFile}"
+      return 1
+    }
     hash -r
     ${SUDO:-} rm -f "${newSoftware}" || true
-    Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    if [[ -z "${CURRENT_VERSION}" ]]; then
+      Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    else
+      Log::displaySuccess "Version ${CURRENT_VERSION} upgraded to ${version} in ${targetFile}"
+    fi
   fi
 }
 
@@ -742,6 +752,7 @@ Github::extractRepoFromGithubUrl() {
 Github::isReleaseVersionExist() {
   local releaseUrl="$1"
 
+  Log::displayDebug "Checking if release version exists on github: ${releaseUrl}"
   curl \
     -L \
     --connect-timeout "${CURL_CONNECT_TIMEOUT:-5}" \
@@ -954,6 +965,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -1706,7 +1746,7 @@ Web::upgradeRelease() {
 
   local currentVersion="not existing"
   if [[ -f "${targetFile}" ]]; then
-    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" 2>&1 || true)"
+    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" || true)"
   fi
   if [[ -z "${exactVersion}" ]]; then
     local latestVersion
@@ -1742,7 +1782,7 @@ Web::upgradeRelease() {
       --fail \
       "${url}"
 
-    Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
+    CURRENT_VERSION="${currentVersion}" Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
   fi
 }
 # FUNCTIONS
@@ -1848,31 +1888,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1906,7 +1921,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1921,7 +1936,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -2454,12 +2469,14 @@ docCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -2477,6 +2494,7 @@ docCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -2493,6 +2511,7 @@ docCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/dockerLint
+++ b/bin/dockerLint
@@ -386,7 +386,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -521,11 +521,21 @@ Github::defaultInstall() {
   if [[ "$(type -t "${installCallback}")" = "function" ]]; then
     ${installCallback} "${newSoftware}" "${targetFile}" "${version}"
   else
-    ${SUDO:-} mv "${newSoftware}" "${targetFile}"
-    ${SUDO:-} chmod +x "${targetFile}"
+    ${SUDO:-} mv "${newSoftware}" "${targetFile}" || {
+      Log::displayError "Failed to move ${newSoftware} to ${targetFile}"
+      return 1
+    }
+    ${SUDO:-} chmod +x "${targetFile}" || {
+      Log::displayError "Failed to set execution bit on ${targetFile}"
+      return 1
+    }
     hash -r
     ${SUDO:-} rm -f "${newSoftware}" || true
-    Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    if [[ -z "${CURRENT_VERSION}" ]]; then
+      Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    else
+      Log::displaySuccess "Version ${CURRENT_VERSION} upgraded to ${version} in ${targetFile}"
+    fi
   fi
 }
 
@@ -553,6 +563,7 @@ Github::extractRepoFromGithubUrl() {
 Github::isReleaseVersionExist() {
   local releaseUrl="$1"
 
+  Log::displayDebug "Checking if release version exists on github: ${releaseUrl}"
   curl \
     -L \
     --connect-timeout "${CURL_CONNECT_TIMEOUT:-5}" \
@@ -744,6 +755,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -1258,7 +1298,7 @@ Web::upgradeRelease() {
 
   local currentVersion="not existing"
   if [[ -f "${targetFile}" ]]; then
-    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" 2>&1 || true)"
+    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" || true)"
   fi
   if [[ -z "${exactVersion}" ]]; then
     local latestVersion
@@ -1294,7 +1334,7 @@ Web::upgradeRelease() {
       --fail \
       "${url}"
 
-    Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
+    CURRENT_VERSION="${currentVersion}" Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
   fi
 }
 # FUNCTIONS
@@ -1400,31 +1440,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1458,7 +1473,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1473,7 +1488,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -2034,12 +2049,14 @@ dockerLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -2057,6 +2074,7 @@ dockerLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -2073,6 +2091,7 @@ dockerLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/findShebangFiles
+++ b/bin/findShebangFiles
@@ -347,7 +347,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -432,7 +432,7 @@ File::detectBashFile() {
         missingBashFileList="$(mktemp -p "${TMPDIR:-/tmp}" -t bash-tools-detectBashFile-before-XXXXXX)"
       fi
       echo "${file}" >>"${missingBashFileList}"
-      return 0
+      continue
     fi
     if Assert::bashFile "${file}"; then
       echo "${file}"
@@ -572,19 +572,6 @@ Log::displayInfo() {
 }
 
 
-# @description Display message using warning color (yellow)
-# @arg $1 message:String the message to display
-# @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
-# @env LOG_CONTEXT String allows to contextualize the log
-Log::displayWarning() {
-  if ((BASH_FRAMEWORK_DISPLAY_LEVEL >= __LEVEL_WARNING)); then
-    Log::computeDuration
-    echo -e "${__WARNING_COLOR}WARN    - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
-  fi
-  Log::logWarning "$1"
-}
-
-
 # @description Display message using error color (red) and exit immediately with error status 1
 # @arg $1 message:String the message to display
 # @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
@@ -594,6 +581,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -664,15 +680,6 @@ Log::logMessage() {
     date="$(date '+%Y-%m-%d %H:%M:%S')"
     touch "${BASH_FRAMEWORK_LOG_FILE}"
     printf "%s|%7s|%s\n" "${date}" "${levelMsg}" "${msg}" >>"${BASH_FRAMEWORK_LOG_FILE}"
-  fi
-}
-
-
-# @description log message to file
-# @arg $1 message:String the message to display
-Log::logWarning() {
-  if ((BASH_FRAMEWORK_LOG_LEVEL >= __LEVEL_WARNING)); then
-    Log::logMessage "${2:-WARNING}" "$1"
   fi
 }
 
@@ -970,31 +977,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1028,7 +1010,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1043,7 +1025,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1542,12 +1524,14 @@ findShebangFilesCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1565,6 +1549,7 @@ findShebangFilesCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1581,6 +1566,7 @@ findShebangFilesCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/frameworkLint
+++ b/bin/frameworkLint
@@ -392,7 +392,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -477,7 +477,7 @@ File::detectBashFile() {
         missingBashFileList="$(mktemp -p "${TMPDIR:-/tmp}" -t bash-tools-detectBashFile-before-XXXXXX)"
       fi
       echo "${file}" >>"${missingBashFileList}"
-      return 0
+      continue
     fi
     if Assert::bashFile "${file}"; then
       echo "${file}"
@@ -711,6 +711,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -1105,31 +1134,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1163,7 +1167,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1178,7 +1182,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1755,12 +1759,14 @@ frameworkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1778,6 +1784,7 @@ frameworkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1794,6 +1801,7 @@ frameworkLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 
@@ -1815,6 +1823,7 @@ frameworkLintCommandHelp() {
   echo "    Possible values: "
   echo -e "      - ${__OPTION_COLOR}plain${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}checkstyle${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "plain"
   echo
 
@@ -2127,7 +2136,8 @@ run() {
     fi
   done < <(
     git ls-files --exclude-standard |
-      xargs -n 10 bash -c 'File::detectBashFile "$@"' ||
+      xargs -n 10 bash -c 'File::detectBashFile "$@" || true' _ |
+      sort ||
       true
   )
 

--- a/bin/installRequirements
+++ b/bin/installRequirements
@@ -429,7 +429,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -629,11 +629,21 @@ Github::defaultInstall() {
   if [[ "$(type -t "${installCallback}")" = "function" ]]; then
     ${installCallback} "${newSoftware}" "${targetFile}" "${version}"
   else
-    ${SUDO:-} mv "${newSoftware}" "${targetFile}"
-    ${SUDO:-} chmod +x "${targetFile}"
+    ${SUDO:-} mv "${newSoftware}" "${targetFile}" || {
+      Log::displayError "Failed to move ${newSoftware} to ${targetFile}"
+      return 1
+    }
+    ${SUDO:-} chmod +x "${targetFile}" || {
+      Log::displayError "Failed to set execution bit on ${targetFile}"
+      return 1
+    }
     hash -r
     ${SUDO:-} rm -f "${newSoftware}" || true
-    Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    if [[ -z "${CURRENT_VERSION}" ]]; then
+      Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    else
+      Log::displaySuccess "Version ${CURRENT_VERSION} upgraded to ${version} in ${targetFile}"
+    fi
   fi
 }
 
@@ -661,6 +671,7 @@ Github::extractRepoFromGithubUrl() {
 Github::isReleaseVersionExist() {
   local releaseUrl="$1"
 
+  Log::displayDebug "Checking if release version exists on github: ${releaseUrl}"
   curl \
     -L \
     --connect-timeout "${CURL_CONNECT_TIMEOUT:-5}" \
@@ -862,6 +873,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -1334,7 +1374,7 @@ Web::upgradeRelease() {
 
   local currentVersion="not existing"
   if [[ -f "${targetFile}" ]]; then
-    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" 2>&1 || true)"
+    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" || true)"
   fi
   if [[ -z "${exactVersion}" ]]; then
     local latestVersion
@@ -1370,7 +1410,7 @@ Web::upgradeRelease() {
       --fail \
       "${url}"
 
-    Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
+    CURRENT_VERSION="${currentVersion}" Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
   fi
 }
 # FUNCTIONS
@@ -1476,31 +1516,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1534,7 +1549,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1549,7 +1564,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -2049,12 +2064,14 @@ installRequirementsCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -2072,6 +2089,7 @@ installRequirementsCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -2088,6 +2106,7 @@ installRequirementsCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/megalinter
+++ b/bin/megalinter
@@ -372,7 +372,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -648,6 +648,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -1138,31 +1167,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1196,7 +1200,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1211,7 +1215,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1968,12 +1972,14 @@ megalinterCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1991,6 +1997,7 @@ megalinterCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -2007,6 +2014,7 @@ megalinterCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 
@@ -2028,6 +2036,7 @@ megalinterCommandHelp() {
   echo "    Possible values: "
   echo -e "      - ${__OPTION_COLOR}plain${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}json${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "plain"
   echo
 
@@ -2050,12 +2059,14 @@ megalinterCommandHelp() {
   Array::wrap2 ' ' 76 4 "    " "Specify docker megalinter image name to use."
   echo
 
+
   Array::wrap2 ' ' 76 6 "    Default value: " "megalinter/megalinter-terraform:v8.3.0"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--config-file <<ConfigFile>>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Specify megalinter config filename to use."
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " ".mega-linter.yml"
   echo

--- a/bin/plantuml
+++ b/bin/plantuml
@@ -332,7 +332,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -543,19 +543,6 @@ Log::displayInfo() {
 }
 
 
-# @description Display message using warning color (yellow)
-# @arg $1 message:String the message to display
-# @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
-# @env LOG_CONTEXT String allows to contextualize the log
-Log::displayWarning() {
-  if ((BASH_FRAMEWORK_DISPLAY_LEVEL >= __LEVEL_WARNING)); then
-    Log::computeDuration
-    echo -e "${__WARNING_COLOR}WARN    - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
-  fi
-  Log::logWarning "$1"
-}
-
-
 # @description Display message using error color (red) and exit immediately with error status 1
 # @arg $1 message:String the message to display
 # @env DISPLAY_DURATION int (default 0) if 1 display elapsed time information between 2 info logs
@@ -565,6 +552,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -635,15 +651,6 @@ Log::logMessage() {
     date="$(date '+%Y-%m-%d %H:%M:%S')"
     touch "${BASH_FRAMEWORK_LOG_FILE}"
     printf "%s|%7s|%s\n" "${date}" "${levelMsg}" "${msg}" >>"${BASH_FRAMEWORK_LOG_FILE}"
-  fi
-}
-
-
-# @description log message to file
-# @arg $1 message:String the message to display
-Log::logWarning() {
-  if ((BASH_FRAMEWORK_LOG_LEVEL >= __LEVEL_WARNING)); then
-    Log::logMessage "${2:-WARNING}" "$1"
   fi
 }
 
@@ -941,31 +948,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -999,7 +981,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1014,7 +996,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1733,12 +1715,14 @@ plantumlCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1756,6 +1740,7 @@ plantumlCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1772,6 +1757,7 @@ plantumlCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 

--- a/bin/shellcheckLint
+++ b/bin/shellcheckLint
@@ -347,7 +347,7 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }
 
@@ -432,7 +432,7 @@ File::detectBashFile() {
         missingBashFileList="$(mktemp -p "${TMPDIR:-/tmp}" -t bash-tools-detectBashFile-before-XXXXXX)"
       fi
       echo "${file}" >>"${missingBashFileList}"
-      return 0
+      continue
     fi
     if Assert::bashFile "${file}"; then
       echo "${file}"
@@ -594,6 +594,35 @@ Log::fatal() {
   echo -e "${__ERROR_COLOR}FATAL   - ${LOG_CONTEXT:-}${LOG_LAST_DURATION_STR:-}${1}${__RESET_COLOR}" >&2
   Log::logFatal "$1"
   exit 1
+}
+
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
 }
 
 
@@ -970,31 +999,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -1028,7 +1032,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1043,7 +1047,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -1684,12 +1688,14 @@ shellcheckLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogLevelDefaultValueFunction)"
   echo
 
   echo -e "  ${__HELP_OPTION_COLOR}--log-file <log-file>${__HELP_NORMAL} {single}"
   Array::wrap2 ' ' 76 4 "    " "Set log file"
   echo
+
 
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionLogFileDefaultValueFunction)"
   echo
@@ -1707,6 +1713,7 @@ shellcheckLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}INFO${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}DEBUG${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}TRACE${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "$(optionDisplayLevelDefaultValueFunction)"
   echo
 
@@ -1723,6 +1730,7 @@ shellcheckLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}default${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}default-force${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}noColor${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "default"
   echo
 
@@ -1749,6 +1757,7 @@ shellcheckLintCommandHelp() {
   echo -e "      - ${__OPTION_COLOR}json1${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}quiet${__RESET_COLOR}"
   echo -e "      - ${__OPTION_COLOR}tty${__RESET_COLOR}"
+
   Array::wrap2 ' ' 76 6 "    Default value: " "tty"
   echo
 

--- a/src/Conf/loadNearestFile.bats
+++ b/src/Conf/loadNearestFile.bats
@@ -14,6 +14,7 @@ setup() {
   export TMPDIR="${BATS_TEST_TMPDIR}"
   mkdir -p "${BATS_TEST_TMPDIR}/dir/dir/dir1"
   mkdir -p "${BATS_TEST_TMPDIR}/dir/dir/dir2"
+  export BASH_FRAMEWORK_DISPLAY_LEVEL="${__LEVEL_DEBUG}"
   echo "echo '.framework-config1 loaded'" >"${BATS_TEST_TMPDIR}/dir/dir/dir1/.framework-config1"
   echo "echo '.framework-config2 loaded'" >"${BATS_TEST_TMPDIR}/dir/dir/.framework-config2"
   echo "echo '.framework-config3 loaded'" >"${BATS_TEST_TMPDIR}/dir/dir/dir2/.framework-config3"

--- a/src/Conf/loadNearestFile.sh
+++ b/src/Conf/loadNearestFile.sh
@@ -31,6 +31,6 @@ Conf::loadNearestFile() {
     fi
   done
 
-  Log::displayWarning "Config file '${configFileName}' not found in any source directories provided"
+  Log::displayDebug "Config file '${configFileName}' not found in any source directories provided"
   return 1
 }

--- a/src/File/detectBashFile.sh
+++ b/src/File/detectBashFile.sh
@@ -21,7 +21,7 @@ File::detectBashFile() {
         missingBashFileList="$(mktemp -p "${TMPDIR:-/tmp}" -t bash-tools-detectBashFile-before-XXXXXX)"
       fi
       echo "${file}" >>"${missingBashFileList}"
-      return 0
+      continue
     fi
     if Assert::bashFile "${file}"; then
       echo "${file}"

--- a/src/Github/defaultInstall.sh
+++ b/src/Github/defaultInstall.sh
@@ -30,10 +30,20 @@ Github::defaultInstall() {
   if [[ "$(type -t "${installCallback}")" = "function" ]]; then
     ${installCallback} "${newSoftware}" "${targetFile}" "${version}"
   else
-    ${SUDO:-} mv "${newSoftware}" "${targetFile}"
-    ${SUDO:-} chmod +x "${targetFile}"
+    ${SUDO:-} mv "${newSoftware}" "${targetFile}" || {
+      Log::displayError "Failed to move ${newSoftware} to ${targetFile}"
+      return 1
+    }
+    ${SUDO:-} chmod +x "${targetFile}" || {
+      Log::displayError "Failed to set execution bit on ${targetFile}"
+      return 1
+    }
     hash -r
     ${SUDO:-} rm -f "${newSoftware}" || true
-    Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    if [[ -z "${CURRENT_VERSION}" ]]; then
+      Log::displaySuccess "Version ${version} installed in ${targetFile}"
+    else
+      Log::displaySuccess "Version ${CURRENT_VERSION} upgraded to ${version} in ${targetFile}"
+    fi
   fi
 }

--- a/src/Github/installRelease.sh
+++ b/src/Github/installRelease.sh
@@ -23,7 +23,7 @@ Github::installRelease() {
 
   local currentVersion="not existing"
   if [[ -f "${targetFile}" ]]; then
-    currentVersion="$(${versionCallback} "${targetFile}" "${argVersion}" 2>&1 || true)"
+    currentVersion="$(${versionCallback} "${targetFile}" "${argVersion}" || true)"
   fi
   if [[ "${currentVersion}" != "${exactVersion}" ]]; then
     Log::displayInfo "Installing ${targetFile} from version ${currentVersion} to ${exactVersion}"

--- a/src/Github/isReleaseVersionExist.sh
+++ b/src/Github/isReleaseVersionExist.sh
@@ -8,6 +8,7 @@
 Github::isReleaseVersionExist() {
   local releaseUrl="$1"
 
+  Log::displayDebug "Checking if release version exists on github: ${releaseUrl}"
   curl \
     -L \
     --connect-timeout "${CURL_CONNECT_TIMEOUT:-5}" \

--- a/src/Log/getLevelText.bats
+++ b/src/Log/getLevelText.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+# shellcheck disable=SC2034
+
+# shellcheck source=src/batsHeaders.sh
+source "$(cd "${BATS_TEST_DIRNAME}/.." && pwd)/batsHeaders.sh"
+# shellcheck source=src/Log/getLevelText.sh
+source "${srcDir}/Log/getLevelText.sh"
+
+function Log::getLevelText::debugLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_DEBUG}")
+  [[ "${levelText}" == "DEBUG" ]]
+}
+
+function Log::getLevelText::infoLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_INFO}")
+  [[ "${levelText}" == "INFO" ]]
+}
+
+function Log::getLevelText::successLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_SUCCESS}")
+  [[ "${levelText}" == "INFO" ]]
+}
+
+function Log::getLevelText::warningLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_WARNING}")
+  [[ "${levelText}" == "WARNING" ]]
+}
+
+function Log::getLevelText::errorLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_ERROR}")
+  [[ "${levelText}" == "ERROR" ]]
+}
+
+function Log::getLevelText::offLevel { #@test
+  local levelText
+  levelText=$(Log::getLevelText "${__LEVEL_OFF}")
+  [[ "${levelText}" == "OFF" ]]
+}
+
+function Log::getLevelText::invalidLevel { #@test
+  run Log::getLevelText "invalid"
+  assert_output --partial "ERROR   - Command test - Invalid level invalid"
+}

--- a/src/Log/getLevelText.sh
+++ b/src/Log/getLevelText.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# @description Get the text representation of a log level
+# @arg $1 level:String the log level to convert
+# @exitcode 1 if the level is invalid
+Log::getLevelText() {
+  local level="$1"
+  case "${level}" in
+    "${__LEVEL_OFF}")
+      echo OFF
+      ;;
+    "${__LEVEL_ERROR}")
+      echo ERROR
+      ;;
+    "${__LEVEL_WARNING}")
+      echo WARNING
+      ;;
+    "${__LEVEL_INFO}")
+      echo INFO
+      ;;
+    "${__LEVEL_DEBUG}")
+      echo DEBUG
+      ;;
+    *)
+      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
+      return 1
+      ;;
+  esac
+}

--- a/src/Web/upgradeRelease.sh
+++ b/src/Web/upgradeRelease.sh
@@ -28,7 +28,7 @@ Web::upgradeRelease() {
 
   local currentVersion="not existing"
   if [[ -f "${targetFile}" ]]; then
-    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" 2>&1 || true)"
+    currentVersion="$(${softVersionCallback} "${targetFile}" "${softVersionArg}" || true)"
   fi
   if [[ -z "${exactVersion}" ]]; then
     local latestVersion
@@ -64,6 +64,6 @@ Web::upgradeRelease() {
       --fail \
       "${url}"
 
-    Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
+    CURRENT_VERSION="${currentVersion}" Github::defaultInstall "${newSoftware}" "${targetFile}" "${exactVersion}" "${installCallback}"
   fi
 }

--- a/src/_binaries/commandDefinitions/optionsDefault.sh
+++ b/src/_binaries/commandDefinitions/optionsDefault.sh
@@ -101,31 +101,6 @@ getLevel() {
   esac
 }
 
-getLevelText() {
-  local level="$1"
-  case "${level}" in
-    "${__LEVEL_OFF}")
-      echo OFF
-      ;;
-    "${__LEVEL_ERROR}")
-      echo ERROR
-      ;;
-    "${__LEVEL_WARNING}")
-      echo WARNING
-      ;;
-    "${__LEVEL_INFO}")
-      echo INFO
-      ;;
-    "${__LEVEL_DEBUG}")
-      echo DEBUG
-      ;;
-    *)
-      Log::displayError "Command ${SCRIPT_NAME} - Invalid level ${level}"
-      return 1
-      ;;
-  esac
-}
-
 getVerboseLevel() {
   local levelName="$1"
   case "${levelName^^}" in
@@ -159,7 +134,7 @@ optionDisplayLevelCallback() {
 }
 
 optionDisplayLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
+  Log::getLevelText "${BASH_FRAMEWORK_DISPLAY_LEVEL:-${__LEVEL_INFO}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden
@@ -174,7 +149,7 @@ optionLogLevelCallback() {
 }
 
 optionLogLevelDefaultValueFunction() {
-  getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
+  Log::getLevelText "${BASH_FRAMEWORK_LOG_LEVEL:-${__LEVEL_OFF}}"
 }
 
 # shellcheck disable=SC2317 # if function is overridden

--- a/src/_binaries/frameworkLint/frameworkLint-main.sh
+++ b/src/_binaries/frameworkLint/frameworkLint-main.sh
@@ -250,7 +250,8 @@ run() {
     fi
   done < <(
     git ls-files --exclude-standard |
-      xargs -n 10 bash -c 'File::detectBashFile "$@"' ||
+      xargs -n 10 bash -c 'File::detectBashFile "$@" || true' _ |
+      sort ||
       true
   )
 


### PR DESCRIPTION
- frameworkLint
  - fixed bug skipping some files
  - File::detectBashFile replaced return by continue
  - excludes files with -options.sh or -main.sh suffix from being checked
  - warnings count 73 -> 62

- better error management and added logs
  - Github::defaultInstall
  - Github::defaultInstall

- clean coding
  - extracted Log::getLevelText
  - changed some log messages levels